### PR TITLE
Allow custom PDF filename to be configured

### DIFF
--- a/docbook-reference-plugin/src/main/groovy/DocbookReferencePlugin.groovy
+++ b/docbook-reference-plugin/src/main/groovy/DocbookReferencePlugin.groovy
@@ -58,8 +58,8 @@ class DocbookReferencePlugin implements Plugin<Project> {
             dependsOn([multi, single, pdf])
 
             ext.sourceDir = null // e.g. new File('src/reference')
-
             ext.outputDir = new File(project.buildDir, "reference")
+            ext.pdfFilename = "${project.rootProject.name}-reference.pdf"
 
             outputs.dir outputDir
         }
@@ -364,7 +364,7 @@ class PdfDocbookReferenceTask extends AbstractDocbookReferenceTask {
     }
 
     private File getPdfOutputFile(File foFile) {
-        return new File(foFile.parent, this.project.rootProject.name + '-reference.pdf')
+        return new File(foFile.parent, project.reference.pdfFilename)
     }
 
 }


### PR DESCRIPTION
The filename of the generated PDF can be specified in the 'reference'
block.  For example:

```
reference {
    sourceDir = file('src/reference/docbook')
    pdfFilename = 'spring-framework-reference.pdf'
}
```

When the pdfFilename is not specified the previous logic of
concatenating the project name with '-reference.pdf' is used.

Issue: SPR-9598
