### PR TITLE
DocbookReferencePlugin.groovy : add ability to pass extra properties through for interpolation

### DIFF
--- a/docbook-reference-plugin/src/main/groovy/DocbookReferencePlugin.groovy
+++ b/docbook-reference-plugin/src/main/groovy/DocbookReferencePlugin.groovy
@@ -169,7 +169,7 @@ abstract class AbstractDocbookReferenceTask extends DefaultTask {
         project.copy {
             into(workDir)
             from(sourceDir) { include '**/index.xml' }
-            expand(version: "${project.version}")
+            expand(version: "${project.version}", ext: project.ext)
         }
 
         // Copy and process any custom titlepages


### PR DESCRIPTION
Use Case : I have a dowloadDomain property I would like to define in my
build.gradle and then have that interpolated in the correct places in my
index.xml (and a good way to do that seems to be exposing 'ext' and
everything it may contain.)
