### PR TITLE
Reference Plugin: Make property sourceFileName configurable

### DIFF
--- a/docbook-reference-plugin/src/main/groovy/DocbookReferencePlugin.groovy
+++ b/docbook-reference-plugin/src/main/groovy/DocbookReferencePlugin.groovy
@@ -164,20 +164,14 @@ abstract class AbstractDocbookReferenceTask extends DefaultTask {
         def workDir = new File("${project.buildDir}/reference-work");
         workDir.mkdirs();
 
-        def expandables
+        def expandables = '**/index.xml'
 
         /*
          * Normally, only index.xml has placeholders expanded. Projects can add other
          * file patterns (comma-delimited) to a property 'expandPlaceholders'.
          */
         if (project.hasProperty('expandPlaceholders')) {
-            expandables = ('**/index.xml,' + "${project.expandPlaceholders}").split(',')
-        }
-        else if (project.hasProperty('neverExpandPlaceholders')) {
-            expandables = ''
-        }
-        else {
-            expandables = '**/index.xml'
+            expandables = project.expandPlaceholders.split(',')
         }
 
         logger.debug('Files that will have placeholders expanded:' + expandables)


### PR DESCRIPTION
- Add ability to completely disable property placeholder expansion

For **Spring XD**, I have been experimenting with incorporating our existing tool-chain with _AsciiDoc_. The idea is that the build of _Spring XD_ checks out the the _Spring XD wiki_, then runs _AsciiDoctor_ on the reference guide section and then the resulting _Docbook_ files are rendered using the _Gradle Reference Plugin_ (PDF and HTML). However 2 changes need to be made:
- The way AsciiDoctor generates the docbook XML, the property expansion/filtering used by the Gradle Reference Plugin causes issues. Thus, I need the ability to disable property expansion altogether, including **index.xml**. I am not too happy with choosing a property **neverExpandPlaceholders** but did not want to break any existing functionality.
- I need a way to make the sourceFileName configurable, right now it expects **index.xml**
