### PR TITLE
Annotate optional inputs with @Optional

### DIFF
--- a/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/AlternativeDependenciesTask.groovy
+++ b/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/AlternativeDependenciesTask.groovy
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -13,11 +14,16 @@ import org.gradle.api.tasks.TaskAction
  * @author Andy Wilkinson
  */
 class AlternativeDependenciesTask extends DefaultTask {
+
 	@OutputFile
 	File reportFile = project.file("$project.buildDir/springio/alternative-dependencies.log")
+
 	@Input
+	@Optional
 	Map<String,String> alternatives
+
 	@Input
+	@Optional
 	Collection<Configuration> configurations
 
 	@TaskAction


### PR DESCRIPTION
Using the plugin with Spring Integration resulted in a failure:

```
* What went wrong:
Some problems were found with the configuration of task ':spring-integration-amqp:springioAlternativeDependenciesCheck'.
> No value has been specified for property 'configurations'.
> No value has been specified for property 'alternatives'.
```

This PR addresses the problem by annotating both configurations and alternatives as `@Optional`
