### PR TITLE
Ensure that springioTestRuntime config contains Spring IO versions

### DIFF
--- a/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/PlatformDependenciesBeforeResolveAction.groovy
+++ b/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/PlatformDependenciesBeforeResolveAction.groovy
@@ -1,0 +1,78 @@
+package org.springframework.build.gradle.springio.platform;
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.DependencyResolveDetails
+import org.gradle.api.artifacts.ModuleVersionSelector
+import org.gradle.api.artifacts.ResolvableDependencies
+import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
+
+/**
+ * @author Rob Winch
+ * @author Andy Wilkinson
+ */
+class PlatformDependenciesBeforeResolveAction implements Action<ResolvableDependencies> {
+
+	Project project
+
+	Configuration configuration
+
+	@Override
+	public void execute(ResolvableDependencies resolvableDependencies) {
+		def action = project.springioPlatform.dependencyResolutionAction;
+		if (!action) {
+			action = createDefaultActionFromStream(project,getClass().getResourceAsStream('springio-dependencies')) 
+		}
+		
+		configuration.resolutionStrategy.eachDependency action
+	}
+
+	/**
+	 * Gets a Map<String,String> such that the key is in the format of "$group:$name" or "$group:" and the value is the
+	 * version to use.
+	 *
+	 * @return
+	 */
+	private static MappingDependencyResolveDetailsAction createDefaultActionFromStream(Project project, InputStream stream) {
+		Map<String,ModuleVersionSelector> depToSelector = [:]
+		stream.eachLine { line ->
+			if(line && !line.startsWith('#')) {
+				def (group, name, version) = line.split(':')
+
+				depToSelector.put("$group:$name".toString(), new DefaultModuleVersionSelector(group, name, version))
+			}
+		}
+		Set<String> ignoredGroupAndNames = project.rootProject.allprojects.collect { "$it.group:$it.name" }
+		new MappingDependencyResolveDetailsAction(depToSelector : depToSelector, ignoredGroupAndNames : ignoredGroupAndNames)
+	}
+
+	private static class MappingDependencyResolveDetailsAction implements Action<DependencyResolveDetails> {
+		Map<String,ModuleVersionSelector> depToSelector = [:]
+		/**
+		 * In the format of group:name
+		 */
+		Set<String> ignoredGroupAndNames = []
+
+		void execute(DependencyResolveDetails details) {
+
+			ModuleVersionSelector requested = details.requested
+			if(ignoredGroupAndNames.contains("$requested.group:$requested.name")) {
+				return
+			}
+
+			ModuleVersionSelector mapping = getMapping("$requested.group:$requested.name") ?: (getMapping("$requested.group:") ?: getMapping(":$requested.name"))
+
+			if(!mapping) {
+				//logger.debug("Did NOT find mapping for $requested.group:$requested.name")
+				return
+			}
+
+			details.useTarget new DefaultModuleVersionSelector( mapping.group ?: requested.group, mapping.name ?: requested.name, mapping.version ?: requested.version)
+		}
+
+		private ModuleVersionSelector getMapping(String id) {
+			depToSelector[id]
+		}
+	}
+}

--- a/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformExtension.groovy
+++ b/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformExtension.groovy
@@ -1,0 +1,19 @@
+package org.springframework.build.gradle.springio.platform
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.DependencyResolveDetails;
+import org.gradle.api.artifacts.ResolutionStrategy
+
+/**
+ * @author Andy Wilkinson
+ */
+class SpringioPlatformExtension {
+
+	/**
+	 * The action to be run against each dependency in the {@code springioTestRuntime}
+	 * configuration. May be {@code null} in which case the default action will be used.
+	 * 
+	 * @see ResolutionStrategy#eachDependency
+	 */
+	def dependencyResolutionAction
+}

--- a/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformPlugin.groovy
+++ b/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformPlugin.groovy
@@ -6,15 +6,14 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.testing.Test
 
 /**
- *
  * @author Rob Winch
+ * @author Andy Wilkinson
  */
 class SpringioPlatformPlugin implements Plugin<Project> {
 	static String CHECK_TASK_NAME = 'springioCheck'
 	static String TEST_TASK_NAME = 'springioTest'
 	static String INCOMPLETE_EXCLUDES_TASK_NAME = 'springioIncompleteExcludesCheck'
 	static String ALTERNATIVE_DEPENDENCIES_TASK_NAME = 'springioAlternativeDependenciesCheck'
-	static String CONFIG_RESOLUTION_STRATEGY_TASK_NAME = 'configureSpringioConfiguration'
 
 	@Override
 	void apply(Project project) {
@@ -28,8 +27,10 @@ class SpringioPlatformPlugin implements Plugin<Project> {
 			extendsFrom project.configurations.testRuntime
 		})
 
-		ConfigureResolutionStrategyTask configureSpringioTask = project.tasks.create(CONFIG_RESOLUTION_STRATEGY_TASK_NAME, ConfigureResolutionStrategyTask)
-		configureSpringioTask.configuration = springioTestRuntimeConfig
+		project.extensions.create("springioPlatform", SpringioPlatformExtension)
+
+		springioTestRuntimeConfig.incoming.beforeResolve(
+			new PlatformDependenciesBeforeResolveAction(project: project, configuration: springioTestRuntimeConfig))
 
 		Task springioTest = project.tasks.create(TEST_TASK_NAME)
 

--- a/springio-platform-plugin/src/test/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformPluginTests.groovy
+++ b/springio-platform-plugin/src/test/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformPluginTests.groovy
@@ -49,6 +49,14 @@ class SpringioPlatformPluginTests extends Specification {
 			project.configurations.springioTestRuntime.extendsFrom.contains(project.configurations.testRuntime)
 	}
 
+	def "Sets up springIoPlatformExtension"() {
+		when:
+			project.apply plugin: SpringioPlatformPlugin
+			project.apply plugin: JavaPlugin
+		then:
+			project.springioPlatform
+	}
+
 	def "Creates springioCheck Task"() {
 		when:
 			project.apply plugin: SpringioPlatformPlugin


### PR DESCRIPTION
Update the Spring IO check task so that it depends on the Spring IO configuration task, thereby ensuring that the springioTestRuntime configuration is populated with the correct versions when it's resolved
