### PR TITLE
Improve handling of unmapped dependencies

### DIFF
--- a/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/PlatformDependenciesBeforeResolveAction.groovy
+++ b/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/PlatformDependenciesBeforeResolveAction.groovy
@@ -1,8 +1,10 @@
 package org.springframework.build.gradle.springio.platform;
 
 import org.gradle.api.Action
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyResolveDetails
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.ResolvableDependencies
@@ -22,10 +24,28 @@ class PlatformDependenciesBeforeResolveAction implements Action<ResolvableDepend
 	public void execute(ResolvableDependencies resolvableDependencies) {
 		def action = project.springioPlatform.dependencyResolutionAction;
 		if (!action) {
-			action = createDefaultActionFromStream(project,getClass().getResourceAsStream('springio-dependencies')) 
+			action = createDefaultActionFromStream(project, configuration, getClass().getResourceAsStream('springio-dependencies')) 
 		}
 		
 		configuration.resolutionStrategy.eachDependency action
+
+		configuration.incoming.afterResolve {
+			if (action instanceof MappingDependencyResolveDetailsAction) {
+				String message
+				if (project.springioPlatform.failOnUnmappedDirectDependency && action.unmappedDirectDependencies) {
+					message = "The following direct dependencies do not have Spring IO versions: " + action.unmappedDirectDependencies.collect { "$it.group:$it.name" }.join(", ")
+				}
+
+				if (project.springioPlatform.failOnUnmappedTransitiveDependency && action.unmappedTransitiveDependencies) {
+					message = message ? message + ". " : ""
+					message += "The following transitive dependencies do not have Spring IO versions: " + action.unmappedTransitiveDependencies.collect { "$it.group:$it.name" }.join(", ")
+				}
+
+				if (message) {
+					throw new InvalidUserDataException(message)
+				}
+			}
+		}
 	}
 
 	/**
@@ -34,7 +54,7 @@ class PlatformDependenciesBeforeResolveAction implements Action<ResolvableDepend
 	 *
 	 * @return
 	 */
-	private static MappingDependencyResolveDetailsAction createDefaultActionFromStream(Project project, InputStream stream) {
+	private static MappingDependencyResolveDetailsAction createDefaultActionFromStream(Project project, Configuration configuration, InputStream stream) {
 		Map<String,ModuleVersionSelector> depToSelector = [:]
 		stream.eachLine { line ->
 			if(line && !line.startsWith('#')) {
@@ -44,11 +64,19 @@ class PlatformDependenciesBeforeResolveAction implements Action<ResolvableDepend
 			}
 		}
 		Set<String> ignoredGroupAndNames = project.rootProject.allprojects.collect { "$it.group:$it.name" }
-		new MappingDependencyResolveDetailsAction(depToSelector : depToSelector, ignoredGroupAndNames : ignoredGroupAndNames)
+		new MappingDependencyResolveDetailsAction(depToSelector : depToSelector, ignoredGroupAndNames : ignoredGroupAndNames, configuration : configuration)
 	}
 
 	private static class MappingDependencyResolveDetailsAction implements Action<DependencyResolveDetails> {
+
+		Configuration configuration
+
 		Map<String,ModuleVersionSelector> depToSelector = [:]
+
+		List<ModuleVersionSelector> unmappedDirectDependencies = []
+
+		List<ModuleVersionSelector> unmappedTransitiveDependencies = []
+
 		/**
 		 * In the format of group:name
 		 */
@@ -64,11 +92,25 @@ class PlatformDependenciesBeforeResolveAction implements Action<ResolvableDepend
 			ModuleVersionSelector mapping = getMapping("$requested.group:$requested.name") ?: (getMapping("$requested.group:") ?: getMapping(":$requested.name"))
 
 			if(!mapping) {
-				//logger.debug("Did NOT find mapping for $requested.group:$requested.name")
+				if (isDirectDependency(requested)) {
+					unmappedDirectDependencies << requested
+				} else {
+					unmappedTransitiveDependencies << requested
+				}
+
 				return
 			}
 
 			details.useTarget new DefaultModuleVersionSelector( mapping.group ?: requested.group, mapping.name ?: requested.name, mapping.version ?: requested.version)
+		}
+
+		private boolean isDirectDependency(ModuleVersionSelector selector) {
+			for (Dependency dependency: configuration.allDependencies) {
+				if (dependency.group == selector.group && dependency.name == selector.name) {
+					return true
+				}
+			}
+			return false
 		}
 
 		private ModuleVersionSelector getMapping(String id) {

--- a/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformExtension.groovy
+++ b/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformExtension.groovy
@@ -16,4 +16,16 @@ class SpringioPlatformExtension {
 	 * @see ResolutionStrategy#eachDependency
 	 */
 	def dependencyResolutionAction
+
+	/**
+	 * Controls whether or not the build will fail when a direct dependency that does not
+	 * have a Spring IO version mapping is encountered. Defaults to {@code true}.
+	 */
+	def failOnUnmappedDirectDependency = true
+
+	/**
+	 * Controls whether or not the build will fail when a transitive dependency that does
+	 * not have a Spring IO version mapping is encountered. Defaults to {@code false}.
+	 */
+	def failOnUnmappedTransitiveDependency = false
 }

--- a/springio-platform-plugin/src/test/groovy/org/springframework/build/gradle/springio/platform/PlatformDependenciesBeforeResolveActionTests.groovy
+++ b/springio-platform-plugin/src/test/groovy/org/springframework/build/gradle/springio/platform/PlatformDependenciesBeforeResolveActionTests.groovy
@@ -1,6 +1,7 @@
 package org.springframework.build.gradle.springio.platform
 
 import org.gradle.api.Action
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyResolveDetails
@@ -29,7 +30,7 @@ class PlatformDependenciesBeforeResolveActionTests extends Specification {
 		parent.version = 'nochange'
 
 		config = parent.configurations.create('configuration')
-		action = new PlatformDependenciesBeforeResolveAction(project:parent, configuration: config)
+		action = new PlatformDependenciesBeforeResolveAction(project: parent, configuration: config)
 
 		child = ProjectBuilder.builder().withName('child').withParent(parent).build()
 		child.group = parent.group
@@ -65,7 +66,7 @@ class PlatformDependenciesBeforeResolveActionTests extends Specification {
 	def "default dependency resolution action supports group only"() {
 		setup:
 			DependencyResolveDetails details = details('grouponly:notdefined:changeme')
-			configureDefaultDependencyResolutionAction(parent)
+			configureDefaultDependencyResolutionAction(parent, config)
 		when:
 			action.execute(Mock(ResolvableDependencies))
 			config.resolutionStrategy.dependencyResolveRule.execute(details)
@@ -78,7 +79,7 @@ class PlatformDependenciesBeforeResolveActionTests extends Specification {
 	def "default dependency resolution action supports name only"() {
 		setup:
 			DependencyResolveDetails details = details('notdefined:nameonly:changeme')
-			configureDefaultDependencyResolutionAction(parent)
+			configureDefaultDependencyResolutionAction(parent, config)
 		when:
 			action.execute(Mock(ResolvableDependencies))
 			config.resolutionStrategy.dependencyResolveRule.execute(details)
@@ -91,7 +92,7 @@ class PlatformDependenciesBeforeResolveActionTests extends Specification {
 	def "default dependency resolution action supports name and group"() {
 		setup:
 			DependencyResolveDetails details = details('standardgroup:standardname:changeme')
-			configureDefaultDependencyResolutionAction(parent)
+			configureDefaultDependencyResolutionAction(parent, config)
 		when:
 			action.execute(Mock(ResolvableDependencies))
 			config.resolutionStrategy.dependencyResolveRule.execute(details)
@@ -104,7 +105,7 @@ class PlatformDependenciesBeforeResolveActionTests extends Specification {
 	def "default dependency resolution action prioritizes both group and name highest"() {
 		setup:
 			DependencyResolveDetails details = details('prioritygroup:priorityname:changeme')
-			configureDefaultDependencyResolutionAction(parent)
+			configureDefaultDependencyResolutionAction(parent, config)
 		when:
 			action.execute(Mock(ResolvableDependencies))
 			config.resolutionStrategy.dependencyResolveRule.execute(details)
@@ -117,7 +118,7 @@ class PlatformDependenciesBeforeResolveActionTests extends Specification {
 	def "default dependency resolution action prioritizes group only second highest"() {
 		setup:
 			DependencyResolveDetails details = details('priority2group:notfound:changeme')
-			configureDefaultDependencyResolutionAction(parent)
+			configureDefaultDependencyResolutionAction(parent, config)
 		when:
 			action.execute(Mock(ResolvableDependencies))
 			config.resolutionStrategy.dependencyResolveRule.execute(details)
@@ -130,7 +131,7 @@ class PlatformDependenciesBeforeResolveActionTests extends Specification {
 	def "default dependency resolution action prioritizes name only second highest"() {
 		setup:
 			DependencyResolveDetails details = details('notfound:priority3name:changeme')
-			configureDefaultDependencyResolutionAction(parent)
+			configureDefaultDependencyResolutionAction(parent, config)
 		when:
 			action.execute(Mock(ResolvableDependencies))
 			config.resolutionStrategy.dependencyResolveRule.execute(details)
@@ -138,22 +139,64 @@ class PlatformDependenciesBeforeResolveActionTests extends Specification {
 			details.target.version == 'priority3nameversion'
 	}
 	
-	def "default dependency resolution action supports notfound"() {
+	def "default dependency resolution action fails with unmapped direct dependency"() {
+		setup:
+			parent.dependencies {
+				configuration "notfound:notfound:nochange"
+			}
+			configureDefaultDependencyResolutionAction(parent, config)
+		when:
+			action.execute(Mock(ResolvableDependencies))
+			config.resolvedConfiguration
+		then:
+			thrown InvalidUserDataException
+	}
+
+	def "default dependency resolution action succeeds with unmapped transitive dependency"() {
 		setup:
 			DependencyResolveDetails details = details('notfound:notfound:nochange')
-			configureDefaultDependencyResolutionAction(parent)
+			configureDefaultDependencyResolutionAction(parent, config)
 		when:
 			action.execute(Mock(ResolvableDependencies))
 			config.resolutionStrategy.dependencyResolveRule.execute(details)
+		then: 'resolution will succeed'
+			config.resolvedConfiguration
+	}
+
+	def "default dependency resolution action can be configured to fail with unmapped transitive dependency"() {
+		setup:
+			DependencyResolveDetails details = details('notfound:notfound:nochange')
+			configureDefaultDependencyResolutionAction(parent, config)
+			parent.springioPlatform {
+				failOnUnmappedTransitiveDependency = true
+			}
+		when:
+			action.execute(Mock(ResolvableDependencies))
+			config.resolutionStrategy.dependencyResolveRule.execute(details)
+			config.resolvedConfiguration
 		then:
-			details.target.version == 'nochange'
-			details.target.name == 'notfound'
-			details.target.group == 'notfound'
+			thrown InvalidUserDataException
+	}
+
+	def "default dependency resolution action can be configured to succeed with unmapped direct dependency"() {
+		setup:
+			parent.dependencies {
+				configuration "notfound:notfound:nochange"
+			}
+			parent.springioPlatform {
+				failOnUnmappedDirectDependency = false
+			}
+			configureDefaultDependencyResolutionAction(parent, config)
+		when:
+			action.execute(Mock(ResolvableDependencies))
+
+		then: 'resolution will succeeed'
+			config.resolvedConfiguration
 	}
 	
-	void configureDefaultDependencyResolutionAction(Project project) {
+	void configureDefaultDependencyResolutionAction(Project project, Configuration configuration) {
 		project.springioPlatform {
-			dependencyResolutionAction = PlatformDependenciesBeforeResolveAction.createDefaultActionFromStream(parent, getClass().getResourceAsStream('test-springio-dependencies'))
+			dependencyResolutionAction = PlatformDependenciesBeforeResolveAction.createDefaultActionFromStream(parent, configuration, getClass().getResourceAsStream('test-springio-dependencies'))
 		}
 	}
 


### PR DESCRIPTION
Previously, all unmapped dependencies were treated equally. With this PR a distinction is now made between unmapped direct dependencies and unmapped transitive dependencies. By default, the build will fail
in the event of one or more unmapped direct dependencies but unmapped transitive dependencies have no effect on the build's outcome. This behaviour can be overridden via the `springioPlatform` extension's `failOnUnmappedDirectDependency` and `failOnUnmappedTransitiveDependency` properties respectively. For example, to only fail on unmapped transitive dependencies:

```
springioPlatform {
    failOnUnmappedDirectDependency = false
    failOnUnmappedTransitiveDependency = true
}
```
