### PR TITLE
Add task to ease checking of version mappings

### DIFF
--- a/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformPlugin.groovy
+++ b/springio-platform-plugin/src/main/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformPlugin.groovy
@@ -14,6 +14,7 @@ class SpringioPlatformPlugin implements Plugin<Project> {
 	static String TEST_TASK_NAME = 'springioTest'
 	static String INCOMPLETE_EXCLUDES_TASK_NAME = 'springioIncompleteExcludesCheck'
 	static String ALTERNATIVE_DEPENDENCIES_TASK_NAME = 'springioAlternativeDependenciesCheck'
+	static String CHECK_DEPENDENCY_VERSION_MAPPING_TASK_NAME = 'springioDependencyVersionMappingCheck'
 
 	@Override
 	void apply(Project project) {
@@ -41,7 +42,12 @@ class SpringioPlatformPlugin implements Plugin<Project> {
 		Task incompleteExcludesCheck = project.tasks.create(INCOMPLETE_EXCLUDES_TASK_NAME, IncompleteExcludesTask)
 		Task alternativeDependenciesCheck = project.tasks.create(ALTERNATIVE_DEPENDENCIES_TASK_NAME, AlternativeDependenciesTask)
 
+		Task dependencyVersionMappingCheck = project.tasks.create(CHECK_DEPENDENCY_VERSION_MAPPING_TASK_NAME) { task ->
+			task << { springioTestRuntimeConfig.resolvedConfiguration }
+		}
+
 		project.tasks.create(CHECK_TASK_NAME) {
+			dependsOn dependencyVersionMappingCheck
 			dependsOn springioTest
 			dependsOn incompleteExcludesCheck
 			dependsOn alternativeDependenciesCheck

--- a/springio-platform-plugin/src/test/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformPluginTests.groovy
+++ b/springio-platform-plugin/src/test/groovy/org/springframework/build/gradle/springio/platform/SpringioPlatformPluginTests.groovy
@@ -64,7 +64,7 @@ class SpringioPlatformPluginTests extends Specification {
 		then:
 			Task sioc = project.tasks.findByName(SpringioPlatformPlugin.CHECK_TASK_NAME)
 			sioc
-			sioc.taskDependencies.getDependencies(sioc) == [springioTestTask, alternativeDependenciesTask, incompleteExcludesTask] as Set
+			sioc.taskDependencies.getDependencies(sioc) == [versionMappingCheckTask, springioTestTask, alternativeDependenciesTask, incompleteExcludesTask] as Set
 	}
 
 	def "Creates springioTest Task"() {
@@ -131,6 +131,14 @@ class SpringioPlatformPluginTests extends Specification {
 			alternativeDependenciesTask instanceof AlternativeDependenciesTask
 	}
 
+	def "Creates springioDependencyVersionMappingCheck task"() {
+		when:
+		project.apply plugin: SpringioPlatformPlugin
+		project.apply plugin: JavaPlugin
+	then:
+		versionMappingCheckTask
+	}
+
 	def getAlternativeDependenciesTask() {
 		project.tasks.findByName(SpringioPlatformPlugin.ALTERNATIVE_DEPENDENCIES_TASK_NAME)
 	}
@@ -149,6 +157,10 @@ class SpringioPlatformPluginTests extends Specification {
 
 	def getJdk8TestTask() {
 		project.tasks.findByName('springioJDK8Test')
+	}
+
+	def getVersionMappingCheckTask() {
+		project.tasks.findByName('springioDependencyVersionMappingCheck')
 	}
 
 	def setupJdks() {


### PR DESCRIPTION
Previously, to check that all of a project's dependencies had Spring IO version mappings it was necessary to run the `springIoCheck` tasks, specifying a JDK 7 and/or JDK 8 home, or to run the `dependencies` task on each module.

To make this process easier, this commit adds a task, that the `springioCheck` task depends on, which causes the `springioTestRuntime` configuration to be resolved thereby triggering a check of its dependency version mapping.

To check that a project's configuration is in good shape you can run `./gradlew springioCheck --continue`. This will check for incomplete excludes, dependencies with preferred alternatives, and for dependencies that don't have an approved Spring IO version.

This PR should be applied after #28
