### PR TITLE
URL Cleanup

### DIFF
--- a/bundlor-plugin/src/main/groovy/BundlorPlugin.groovy
+++ b/bundlor-plugin/src/main/groovy/BundlorPlugin.groovy
@@ -8,8 +8,8 @@ import org.gradle.api.logging.LogLevel
  *
  * @author Chris Beams
  * @author Luke Taylor
- * @see http://www.springsource.org/bundlor
- * @see http://static.springsource.org/s2-bundlor/1.0.x/user-guide/html/ch04s02.html
+ * @see https://www.springsource.org/bundlor
+ * @see https://docs.spring.io/s2-bundlor/1.0.x/user-guide/html/ch04s02.html
  */
 public class BundlorPlugin implements Plugin<Project> {
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://static.springsource.org/s2-bundlor/1.0.x/user-guide/html/ch04s02.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/s2-bundlor/1.0.x/user-guide/html/ch04s02.html ([https](https://static.springsource.org/s2-bundlor/1.0.x/user-guide/html/ch04s02.html) result 301).
* [ ] http://www.springsource.org/bundlor with 1 occurrences migrated to:  
  https://www.springsource.org/bundlor ([https](https://www.springsource.org/bundlor) result 301).